### PR TITLE
Remove unnecessary dependencies in generate_messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ add_message_files(
 
 
 generate_messages(
-  DEPENDENCIES std_msgs sensor_msgs cv_bridge vision_opencv
+  DEPENDENCIES std_msgs sensor_msgs
 )
 
 


### PR DESCRIPTION
It causes some errors in catkin_make in my environment.